### PR TITLE
Fixed "access denied" message to tell users that are not logged in, that...

### DIFF
--- a/src/MGRAST/lib/WebPage/MetagenomeOverview.pm
+++ b/src/MGRAST/lib/WebPage/MetagenomeOverview.pm
@@ -73,7 +73,7 @@ sub init {
 
     if(! $job->public) {
       if(! $user) {
-        $self->app->add_message('warning', 'Please log into MG-RAST to view metagenomes.');
+        $self->app->add_message('warning', 'Please log into MG-RAST to view private metagenomes.');
         return 1;
       } elsif(! $user->has_right(undef, 'view', 'metagenome', $id)) {
         $self->app->add_message('warning', "You have no access to the metagenome '$id'.  If someone is sharing this data with you please contact them with inquiries.  However, if you believe you have reached this message in error please contact the <a href='mailto:mg-rast\@mcs.anl.gov'>MG-RAST mailing list</a>.");


### PR DESCRIPTION
... they need to log in (and nothing else).  MG-RAST dev email and access privilege error are only shown to logged in users.
