### PR TITLE
metagenome resource invalid data -> die

### DIFF
--- a/src/MGRAST/lib/resources2/metagenome.pm
+++ b/src/MGRAST/lib/resources2/metagenome.pm
@@ -191,9 +191,18 @@ sub prepare_data {
                 $obj->{metadata} = $jobdata->{$job->{metagenome_id}};
             }
             if (($self->cgi->param('verbosity') eq 'verbose') || ($self->cgi->param('verbosity') eq 'full')) {
-                my $proj = $job->primary_project;
-                my $samp = $job->sample;
-                my $lib  = $job->library;
+                my $proj;
+		eval {
+		  $proj = $job->primary_project;
+		};
+                my $samp;
+		eval {
+		  $samp = $job->sample;
+		};
+                my $lib;
+		eval {
+		  $lib = $job->library;
+		};
                 $obj->{sequence_type} = $job->{sequence_type};
                 $obj->{version} = 1;
                 $obj->{project} = $proj ? ["mgp".$proj->{id}, $url."/project/mgp".$proj->{id}] : undef;


### PR DESCRIPTION
added evals to the calls to library, project and sample. There is an invalid reference in one of the metagenomes to a library and a sample that cause the api call to die.
