### PR TITLE
For some odd reason, perl doesn't like the escaped single quote at the e...

### DIFF
--- a/src/WebApplication/WebComponent/Register.pm
+++ b/src/WebApplication/WebComponent/Register.pm
@@ -212,7 +212,7 @@ sub perform_registration {
   }
 
   # check if email address is valid
-  unless ($cgi->param('email') =~ /^[\d\w\.-\']+\@[\d\w\.-]+\.[\w+]$/) {
+  unless ($cgi->param('email') =~ /^[\d\w\.\'-]+\@[\d\w\.-]+\.[\w+]$/) {
     $application->add_message('warning', 'You must enter a valid eMail address.');
     return 0;
   }


### PR DESCRIPTION
...nd of a range in a regular expression. Didn't figure out why, but moving it to a different position in the range fixed the issue. The User Registration page was not showing until this change was made.
