### PR TITLE
Another odd issue in the regex that was updated recently for allowing si...

### DIFF
--- a/src/WebApplication/WebComponent/Register.pm
+++ b/src/WebApplication/WebComponent/Register.pm
@@ -212,7 +212,7 @@ sub perform_registration {
   }
 
   # check if email address is valid
-  unless ($cgi->param('email') =~ /^[\d\w\.\'-]+\@[\d\w\.-]+\.[\w+]$/) {
+  unless ($cgi->param('email') =~ /[\d\w\.\'-]+\@[\d\w\.-]+\.[\w+]/) {
     $application->add_message('warning', 'You must enter a valid eMail address.');
     return 0;
   }


### PR DESCRIPTION
...ngle quotes in email addresses.  Apparently anchoring the start and end of the regex was causing nothing to match.  Removed the anchors but left the single quote option in place.
