### PR TITLE
Added code to prevent undef perl variables from being converted to empty...

### DIFF
--- a/src/PPO/PPOBackend.pm
+++ b/src/PPO/PPOBackend.pm
@@ -9,8 +9,7 @@ use warnings;
 use DBI;
 
 use HTML::Strip;
-
-
+use Scalar::Util qw(looks_like_number);
 
 =pod
 
@@ -528,13 +527,14 @@ Returns the quoted I<value>.
 sub quote {
   my ($self, $value) = @_;
 
-  unless ($value) { return ""; }
+  my $clean_text = $value;
+  if(defined $value && !looks_like_number($value)) {
+    my $hs = HTML::Strip->new();
+    my $clean_text = $hs->parse($value);
+    $clean_text =~ s/\n//g;
+    $hs->eof;
+  }
 
-  my $hs = HTML::Strip->new();
-  my $clean_text = $hs->parse($value);
-  $clean_text =~ s/\n//g;
-  $hs->eof;
-  
   return $self->dbh->quote($clean_text);
 }
 


### PR DESCRIPTION
... strings by HTML::Strip when entering them into a database in PPOBacken.pm.  Also, skipped the HTML stripping if the variable looks like a numeric value.
