### PR TITLE
Added sort_by and sort_dir to solr query call to sort by a return field ...

### DIFF
--- a/src/MGRAST/lib/resources2/m5nr.pm
+++ b/src/MGRAST/lib/resources2/m5nr.pm
@@ -379,7 +379,7 @@ sub solr_data {
         $text = '*'.$text.'*';
     }
     my $fields = ['source', 'function', 'accession', 'organism', 'ncbi_tax_id', 'type', 'md5'];
-    return $self->get_solr_query($Conf::m5nr_solr, $Conf::m5nr_collect, $field.'%3A'.$text, $offset, $limit, $fields);
+    return $self->get_solr_query($Conf::m5nr_solr, $Conf::m5nr_collect, $field.'%3A'.$text, "", $offset, $limit, $fields);
 }
 
 1;

--- a/src/MGRAST/lib/resources2/resource.pm
+++ b/src/MGRAST/lib/resources2/resource.pm
@@ -538,10 +538,10 @@ sub get_shock_query {
 }
 
 sub get_solr_query {
-    my ($self, $server, $collect, $query, $offset, $limit, $fields) = @_;
+    my ($self, $server, $collect, $query, $sort_field, $offset, $limit, $fields) = @_;
     
     my $data = undef;
-    my $url = $server.'/'.$collect.'/select?q=*%3A*&fq='.$query.'&start='.$offset.'&rows='.$limit.'&wt=json';
+    my $url = $server.'/'.$collect.'/select?q=*%3A*&fq='.$query.'&start='.$offset.'&rows='.$limit.'&wt=json&sort='.$sort_field;
     if ($fields && (@$fields > 0)) {
         $url .= '&fl='.join('%2C', @$fields);
     }


### PR DESCRIPTION
...and choose the sort direction (asc or desc).  Added these options to the search resource along with an option to search metagenomes by md5.  Added job number and PI_lastname to solr schema so we can retrieve that information directly from solr and added those to the search resource.

Note: the sort field passed to the get_solr_query subroutine is actually one of 'field asc' or 'field desc'.  The field and sort direction should be passed in one string separated by a space.
