### PR TITLE
adding user object to JobDB master in resource->connect_to_datasource

### DIFF
--- a/src/MGRAST/lib/resources/resource.pm
+++ b/src/MGRAST/lib/resources/resource.pm
@@ -436,7 +436,10 @@ sub connect_to_datasource {
     if ($@ || $error || (! $master)) {
         $self->return_data({ "ERROR" => "resource database offline" }, 503);
     } else {
-        return $master;
+      if (ref $self->user) {
+	$master->{_user} = $self->user;
+      }
+      return $master;
     }
 }
 


### PR DESCRIPTION
This fixes the issue of a project not having access to private metagenomes even if an authorized user is passed.