### PR TITLE
feature additions / bug fixes

### DIFF
--- a/bin/download_m5nr_blast.sh
+++ b/bin/download_m5nr_blast.sh
@@ -2,7 +2,7 @@
 
 # set a default values
 # m5nr blast files - 2.6 GB & 11.7 GB
-M5NR_VERSIONS="20100309 20131215"
+M5NR_VERSIONS="20100309 20120401 20131215"
 TARGET="/m5nr"
 
 for i in $M5NR_VERSIONS; do

--- a/dockerfiles/api/Dockerfile
+++ b/dockerfiles/api/Dockerfile
@@ -37,7 +37,7 @@ RUN mkdir -p /MG-RAST /var/log/httpd/api.metagenomics
 COPY . /MG-RAST
 RUN cd /MG-RAST && \
   make && \
-#  make api-doc && \
+  make api-doc && \
   cp -rv src/MGRAST/bin/* bin/. && \
   cd site/CGI && \
   rm -fv metagenomics.cgi linkin.cgi m5nr.cgi m5nr_rest.cgi

--- a/dockerfiles/api/Dockerfile
+++ b/dockerfiles/api/Dockerfile
@@ -59,12 +59,6 @@ RUN apt-get install -y python-dev python-pip && \
 ENV PERL_MM_USE_DEFAULT 1
 RUN cpan Inline::Python
 
-# setup sendmail
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install postfix && \
-  cp /usr/share/postfix/main.cf.debian /etc/postfix/main.cf && \
-  postconf -e relayhost=[smtp.mcs.anl.gov] && \
-  postconf -e myorigin=mcs.anl.gov
-
 RUN mkdir -p /sites/1/ && \
   cd /sites/1/ && \
   ln -s /MG-RAST/

--- a/dockerfiles/api/Dockerfile
+++ b/dockerfiles/api/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y \
   libpq-dev \
   make \
   curl \
+  ncbi-blast+ \
   perl-modules \
   liburi-perl \
   libwww-perl \
@@ -75,9 +76,7 @@ RUN cd /MG-RAST/conf && ln -s /api-server-conf/Conf.pm
 RUN ln -s /api-server-conf/postgresql/ /usr/sbin/.postgresql
 
 # m5nr blast files in mounted dir
-RUN mkdir -p /m5nr && \
-  ln -s /api-server-data/20100309 /m5nr/20100309 && \
-  ln -s /api-server-data/20131215 /m5nr/20131215
+RUN mkdir -p /m5nr
 
 # Execute:
 # /etc/init.d/postfix start

--- a/src/MGRAST/lib/Abundance.pm
+++ b/src/MGRAST/lib/Abundance.pm
@@ -159,7 +159,6 @@ sub all_job_abundances {
                 }
             }
             if ($org && $set->{organism}) {
-                print STDERR Dumper($set->{organism});
                 foreach my $o (@{$set->{organism}}) {
                     if ($tax) {
                         next if (($tax eq 'domain') && ($tax_map->{$o} =~ /other|unknown|unclassified/));

--- a/src/MGRAST/lib/resources/annotation.pm
+++ b/src/MGRAST/lib/resources/annotation.pm
@@ -22,32 +22,35 @@ sub new {
     
     # Add name / attributes
     $self->{name}  = "annotation";
-    $self->{types} = [[ "organism", "return organism data" ],
-                      [ "function", "return function data" ],
-                      [ "ontology", "return ontology data" ],
-                      [ "feature", "return feature data" ],
-                      [ "md5", "return md5sum data" ]];
+    $self->{types} = [
+        [ "organism", "return organism data" ],
+        [ "function", "return function data" ],
+        [ "ontology", "return ontology data" ],
+        [ "feature", "return feature data" ]
+    ];
     $self->{cutoffs}  = { evalue => '5', identity => '60', length => '15' };
-    $self->{attributes} = { sequence => {
-                                "col_01" => ['string', 'sequence id'],
-                                "col_02" => ['string', 'm5nr id (md5sum)'],
-                                "col_03" => ['string', 'dna sequence'],
-                                "col_04" => ['string', 'semicolon separated list of annotations'] },
-                            similarity => {
-                                "col_01" => ['string', 'query sequence id'],
-                                "col_02" => ['string', 'hit m5nr id (md5sum)'],
-                                "col_03" => ['float', 'percentage identity'],
-                                "col_04" => ['int', 'alignment length,'],
-                                "col_05" => ['int', 'number of mismatches'],
-                                "col_06" => ['int', 'number of gap openings'],
-                                "col_07" => ['int', 'query start'],
-                                "col_08" => ['int', 'query end'],
-                                "col_09" => ['int', 'hit start'],
-                                "col_10" => ['int', 'hit end'],
-                                "col_11" => ['float', 'e-value'],
-                                "col_12" => ['float', 'bit score'],
-                                "col_13" => ['string', 'semicolon separated list of annotations'] }
-                          };
+    $self->{attributes} = {
+        sequence => {
+            "col_01" => ['string', 'sequence id'],
+            "col_02" => ['string', 'm5nr id (md5sum)'],
+            "col_03" => ['string', 'dna sequence'],
+            "col_04" => ['string', 'semicolon separated list of annotations']
+        },
+        similarity => {
+            "col_01" => ['string', 'query sequence id'],
+            "col_02" => ['string', 'hit m5nr id (md5sum)'],
+            "col_03" => ['float', 'percentage identity'],
+            "col_04" => ['int', 'alignment length,'],
+            "col_05" => ['int', 'number of mismatches'],
+            "col_06" => ['int', 'number of gap openings'],
+            "col_07" => ['int', 'query start'],
+            "col_08" => ['int', 'query end'],
+            "col_09" => ['int', 'hit start'],
+            "col_10" => ['int', 'hit end'],
+            "col_11" => ['float', 'e-value'],
+            "col_12" => ['float', 'bit score'],
+            "col_13" => ['string', 'semicolon separated list of annotations'] }
+    };
     return $self;
 }
 
@@ -81,15 +84,35 @@ sub info {
 				          'type'        => "stream",  
 				          'attributes'  => { "streaming text" => ['object', [$self->{attributes}{sequence}, "tab delimited annotated sequence stream"]] },
 				          'parameters'  => { 'required' => { "id" => [ "string", "unique metagenome identifier" ] },
-				                             'options' => { 'evalue'   => ['int', 'negative exponent value for maximum e-value cutoff: default is '.$self->{cutoffs}{evalue}],
-                                                            'identity' => ['int', 'percent value for minimum % identity cutoff: default is '.$self->{cutoffs}{identity}],
-                                                            'length'   => ['int', 'value for minimum alignment length cutoff: default is '.$self->{cutoffs}{length}],
-                                                            "filter"   => ['string', 'text string to filter annotations by: only return those that contain text'],
-				                                            "type"     => ["cv", $self->{types} ],
-									                        "source"   => ["cv", $sources ],
-									                        'version'  => ['integer', 'M5NR version, default is '.$self->{m5nr_default}],
-									                        "filter_level" => ['string', 'hierarchal level to filter annotations by, for organism or ontology only'] },
+				                             'options' => {
+				                                 'evalue'   => ['int', 'negative exponent value for maximum e-value cutoff: default is '.$self->{cutoffs}{evalue}],
+                                                 'identity' => ['int', 'percent value for minimum % identity cutoff: default is '.$self->{cutoffs}{identity}],
+                                                 'length'   => ['int', 'value for minimum alignment length cutoff: default is '.$self->{cutoffs}{length}],
+                                                 "version"  => ['integer', 'M5NR version, default is '.$self->{m5nr_default}],
+                                                 "source"   => ['cv', $sources ],
+                                                 "type"     => ['cv', $self->{types} ],
+                                                 "filter"   => ['string', 'text string to filter annotations by: only return those that contain text'],
+                                                 "filter_level" => ['string', 'hierarchal level to filter annotations by, for organism or ontology only']
+                                             },
 							                 'body' => {} }
+						},
+						{ 'name'        => "sequence",
+				          'request'     => $self->cgi->url."/".$self->name."/sequence/{ID}",
+				          'description' => "tab delimited annotated sequence stream",
+				          'example'     => [ 'curl -X POST -d \'{"source":"SwissProt","type":"organism","data":["000821a2e2f63df1a3873e4b280002a8","15bf1950bd9867099e72ea6516e3d602"]}\' "'.$self->{url}."/".$self->name.'/sequence/mgm4447943.3"', 'annotated read sequences from mgm4447943.3 with hits in SwissProt organisms for given md5s' ],
+				          'method'      => "POST",
+				          'type'        => "stream",  
+				          'attributes'  => { "streaming text" => ['object', [$self->{attributes}{sequence}, "tab delimited annotated sequence stream"]] },
+				          'parameters'  => { 'required' => { "id" => [ "string", "unique metagenome identifier" ] },
+				                             'options' => {},
+							                 'body' => {
+							                     "md5s"    => ['list', ["string","md5 to get hits for"]],
+							                     "version" => ['integer', 'M5NR version, default is '.$self->{m5nr_default}],
+							                     "source"  => ['cv', $sources ],
+							                     "type"    => ['cv', [ $self->{types} ],
+							                     "filter"  => ['string', 'text string to filter annotations by: only return those that contain text'],
+							                     "filter_level" => ['string', 'hierarchal level to filter annotations by, for organism or ontology only']
+						                     } }
 						},
 						{ 'name'        => "similarity",
 				          'request'     => $self->cgi->url."/".$self->name."/similarity/{ID}",
@@ -100,16 +123,37 @@ sub info {
 				          'type'        => "stream",  
 				          'attributes'  => { "streaming text" => ['object', [$self->{attributes}{similarity}, "tab delimited blast m8 with annotation"]] },
 				          'parameters'  => { 'required' => { "id" => [ "string", "unique metagenome identifier" ] },
-				                             'options' => { 'evalue'   => ['int', 'negative exponent value for maximum e-value cutoff: default is '.$self->{cutoffs}{evalue}],
-                                                            'identity' => ['int', 'percent value for minimum % identity cutoff: default is '.$self->{cutoffs}{identity}],
-                                                            'length'   => ['int', 'value for minimum alignment length cutoff: default is '.$self->{cutoffs}{length}],
-                                                            "filter"   => ['string', 'text string to filter annotations by: only return those that contain text'],
-				                                            "type"     => ["cv", $self->{types} ],
-									                        "source"   => ["cv", $sources ],
-									                        'version'  => ['integer', 'M5NR version, default is '.$self->{m5nr_default}],
-									                        "filter_level" => ['string', 'hierarchal level to filter annotations by, for organism or ontology only'] },
-							                 'body' => {} }
-						} ]
+				                             'options' => {
+				                                 'evalue'   => ['int', 'negative exponent value for maximum e-value cutoff: default is '.$self->{cutoffs}{evalue}],
+                                                 'identity' => ['int', 'percent value for minimum % identity cutoff: default is '.$self->{cutoffs}{identity}],
+                                                 'length'   => ['int', 'value for minimum alignment length cutoff: default is '.$self->{cutoffs}{length}],
+                                                 "version"  => ['integer', 'M5NR version, default is '.$self->{m5nr_default}],
+                                                 "source"   => ['cv', $sources ],
+                                                 "type"     => ['cv', $self->{types} ],
+                                                 "filter"   => ['string', 'text string to filter annotations by: only return those that contain text'],
+                                                 "filter_level" => ['string', 'hierarchal level to filter annotations by, for organism or ontology only']
+                                             },
+				                             'body' => {} }
+						},
+						{ 'name'        => "similarity",
+				          'request'     => $self->cgi->url."/".$self->name."/similarity/{ID}",
+				          'description' => "tab delimited blast m8 with annotation",
+				          'example'     => [ 'curl -X POST -d \'{"source":"KO","type":"function","data":["000821a2e2f63df1a3873e4b280002a8","15bf1950bd9867099e72ea6516e3d602"]}\' "'.$self->{url}."/".$self->name.'/sequence/mgm4447943.3"', 'annotated read blast stats from mgm4447943.3 with hits in KO functions for given md5s' ],
+				          'method'      => "POST",
+				          'type'        => "stream",  
+				          'attributes'  => { "streaming text" => ['object', [$self->{attributes}{similarity}, "tab delimited blast m8 with annotation"]] },
+				          'parameters'  => { 'required' => { "id" => [ "string", "unique metagenome identifier" ] },
+				                             'options' => {},
+				                             'body' => {
+ 							                     "md5s"    => ['list', ["string","md5 to get hits for"]],
+ 							                     "version" => ['integer', 'M5NR version, default is '.$self->{m5nr_default}],
+ 							                     "source"  => ['cv', $sources ],
+ 							                     "type"    => ['cv', [ $self->{types} ],
+ 							                     "filter"  => ['string', 'text string to filter annotations by: only return those that contain text'],
+ 							                     "filter_level" => ['string', 'hierarchal level to filter annotations by, for organism or ontology only']
+ 						                     } }
+						}
+					]
 		  };
 
     $self->return_data($content);
@@ -179,16 +223,12 @@ sub prepare_data {
         if ($post_data) {
             eval {
                 my $json_data = $self->json->decode($post_data);
-                if (exists $json_data->{type})     { $type   = $json_data->{type}; }
-                if (exists $json_data->{source})   { $source = $json_data->{source}; }
-                if (exists $json_data->{evalue})   { $eval   = $json_data->{evalue}; }
-                if (exists $json_data->{identity}) { $ident  = $json_data->{identity}; }
-                if (exists $json_data->{length})   { $alen   = $json_data->{length}; }
-                if ($type eq 'md5') {
-                    $filter = undef;
-                    $flevel = undef;
-                    $md5s = $json_data->{md5s};
-                }
+                if (exists $json_data->{md5s})    { $md5s    = $json_data->{md5s}; }
+                if (exists $json_data->{type})    { $type    = $json_data->{type}; }
+                if (exists $json_data->{version}) { $version = $json_data->{version}; }
+                if (exists $json_data->{source})  { $source  = $json_data->{source}; }
+                if (exists $json_data->{filter})  { $filter  = $json_data->{filter}; }
+                if (exists $json_data->{filter_level}) { $flevel = $json_data->{filter_level}; }
             };
         # data sent in post form
         } elsif ($self->cgi->param('md5s')) {
@@ -201,10 +241,9 @@ sub prepare_data {
         if ($@ || (@$md5s == 0)) {
             $self->return_data( {"ERROR" => "unable to obtain POSTed data: ".$@}, 500 );
         }
-    } elsif ($filter && ($type eq 'md5')) {
-        $filter = undef;
-        $flevel = undef;
-        $md5s = [$filter];
+        $eval  = undef;
+        $ident = undef;
+        $alen  = undef;
     }
 
     # validate options

--- a/src/MGRAST/lib/resources/annotation.pm
+++ b/src/MGRAST/lib/resources/annotation.pm
@@ -102,7 +102,7 @@ sub info {
 						{ 'name'        => "sequence",
 				          'request'     => $self->cgi->url."/".$self->name."/sequence/{ID}",
 				          'description' => "tab delimited annotated sequence stream",
-				          'example'     => [ 'curl -X POST -d \'{"source":"SwissProt","type":"organism","data":["000821a2e2f63df1a3873e4b280002a8","15bf1950bd9867099e72ea6516e3d602"]}\' "'.$self->{url}."/".$self->name.'/sequence/mgm4447943.3"', 'annotated read sequences from mgm4447943.3 with hits in SwissProt organisms for given md5s' ],
+				          'example'     => [ 'curl -X POST -d \'{"source":"SwissProt","type":"organism","data":["000821a2e2f63df1a3873e4b280002a8","15bf1950bd9867099e72ea6516e3d602"]}\' "'.$self->cgi->url."/".$self->name.'/sequence/mgm4447943.3"', 'annotated read sequences from mgm4447943.3 with hits in SwissProt organisms for given md5s' ],
 				          'method'      => "POST",
 				          'type'        => "stream",  
 				          'attributes'  => { "streaming text" => ['object', [$self->{attributes}{sequence}, "tab delimited annotated sequence stream"]] },
@@ -113,7 +113,7 @@ sub info {
 							                     "format"  => ['cv', [["tabbed", "tab-delimited text file"], ["fasta", "fasta format text file"]] ],
 							                     "version" => ['integer', 'M5NR version, default is '.$self->{m5nr_default}],
 							                     "source"  => ['cv', $sources ],
-							                     "type"    => ['cv', [ $self->{types} ]
+							                     "type"    => ['cv', $self->{types} ]
 						                     } }
 						},
 						{ 'name'        => "similarity",
@@ -140,7 +140,7 @@ sub info {
 						{ 'name'        => "similarity",
 				          'request'     => $self->cgi->url."/".$self->name."/similarity/{ID}",
 				          'description' => "tab delimited blast m8 with annotation",
-				          'example'     => [ 'curl -X POST -d \'{"source":"KO","type":"function","data":["000821a2e2f63df1a3873e4b280002a8","15bf1950bd9867099e72ea6516e3d602"]}\' "'.$self->{url}."/".$self->name.'/sequence/mgm4447943.3"', 'annotated read blast stats from mgm4447943.3 with hits in KO functions for given md5s' ],
+				          'example'     => [ 'curl -X POST -d \'{"source":"KO","type":"function","data":["000821a2e2f63df1a3873e4b280002a8","15bf1950bd9867099e72ea6516e3d602"]}\' "'.$self->cgi->url."/".$self->name.'/sequence/mgm4447943.3"', 'annotated read blast stats from mgm4447943.3 with hits in KO functions for given md5s' ],
 				          'method'      => "POST",
 				          'type'        => "stream",  
 				          'attributes'  => { "streaming text" => ['object', [$self->{attributes}{similarity}, "tab delimited blast m8 with annotation"]] },
@@ -150,7 +150,7 @@ sub info {
  							                     "md5s"    => ['list', ["string","md5 to get hits for"]],
  							                     "version" => ['integer', 'M5NR version, default is '.$self->{m5nr_default}],
  							                     "source"  => ['cv', $sources ],
- 							                     "type"    => ['cv', [ $self->{types} ]
+ 							                     "type"    => ['cv', $self->{types} ]
  						                     } }
 						}
 					]
@@ -395,7 +395,7 @@ sub print_batch {
             if ($filter) {
                 @ann = map {["", $_, ""]} grep { /$filter/i } @{$set->{accession}};
             } else {
-                @ann = map {["", $_, ""]} @{$set->{accession};
+                @ann = map {["", $_, ""]} @{$set->{accession}};
             }
         } elsif ($type eq 'organism') {
             if (%$filter_list) {
@@ -448,7 +448,7 @@ sub print_batch {
             }
         }
         if (@found == 0) { next; }
-        my $ann_str = join(";", @$found);
+        my $ann_str = join(";", @found);
         
         # pull data from indexed shock file
         my ($seek, $len) = @{$md5s->{$set->{id}}};

--- a/src/MGRAST/lib/resources/annotation.pm
+++ b/src/MGRAST/lib/resources/annotation.pm
@@ -428,14 +428,14 @@ sub print_batch {
                 push @$line, "function=[".$a->[1]."]";
             }
             if ($a->[2]) {
-                push @$line, "organism=[".$a->[3]."]";
+                push @$line, "organism=[".$a->[2]."]";
             }
             if (@$line > 0) {
                 push @found, $line;
             }
         }
         if (@found == 0) { next; }
-        my $ann_str = join("||", map { join(";", @$_) } @found);
+        my $ann_str = join("|", map { join(";", @$_) } @found);
         
         # pull data from indexed shock file
         my ($seek, $len) = @{$md5s->{$set->{id}}};

--- a/src/MGRAST/lib/resources/annotation.pm
+++ b/src/MGRAST/lib/resources/annotation.pm
@@ -280,6 +280,9 @@ sub prepare_data {
     # get db handles
     my $chdl = $self->cassandra_m5nr_handle("m5nr_v".$version, $Conf::cassandra_m5nr);
     my $mgdb = MGRAST::Abundance->new($chdl, $version);
+    unless ($mgdb) {
+        $self->return_data({"ERROR" => "Unable to connect to metagenomics analysis database"}, 500);
+    }
     
     # build queries
     $eval  = (defined($eval)  && ($eval  =~ /^\d+$/)) ? "exp_avg <= " . ($eval * -1) : "";

--- a/src/MGRAST/lib/resources/compute.pm
+++ b/src/MGRAST/lib/resources/compute.pm
@@ -365,6 +365,7 @@ sub sequence_compute {
     
     # get sequences from record
     my $infasta = "";
+    my $reads = [];
     my ($rec, $err) = $self->get_shock_file($node_id, undef, $self->mgrast_token, 'seek='.$info->[0].'&length='.$info->[1]);
     if ($err) {
 	    return ({"ERROR" => "unable to download: $err"}, 500);
@@ -374,7 +375,9 @@ sub sequence_compute {
         my @tabs = split(/\t/, $line);
         unless ($tabs[0]) { next; }
         if (@tabs == 13) {
-            $infasta .= ">".$mgid."|".$tabs[0]."\n".$tabs[12]."\n";
+            my $rid = $mgid."|".$tabs[0];
+            $infasta .= ">".$rid."\n".$tabs[12]."\n";
+            push @$reads, $rid;
         }
     }
     
@@ -393,7 +396,7 @@ sub sequence_compute {
     my $opts = "-evalue 0.".("0" x ($eval-1))."1 -dbsize ".$self->{dbsize}." -outfmt 0";
     my $data = `echo "$infasta" | $cmd $opts -query - -subject $tfile 2> /dev/null`;
     
-    return ({alignment => $data, md5 => $md5}, undef);
+    return ({alignment => $data, md5 => $md5, reads => $reads}, undef);
 }
 
 # compute alpha diversity and/or rarefaction

--- a/src/MGRAST/lib/resources/heartbeat.pm
+++ b/src/MGRAST/lib/resources/heartbeat.pm
@@ -26,8 +26,8 @@ sub new {
       'AWEDB' => 'mongo',
       'M5NR' => $Conf::m5nr_solr,
       'solr' => $Conf::job_solr,
-      'postgresW' => 'db',
-      'postgresR' => 'db',
+      'postgresWRITE' => 'db',
+      'postgresREAD' => 'db',
       'mySQL' => 'db',
       'cassandra' => $Conf::cassandra_m5nr
   };
@@ -40,8 +40,8 @@ sub new {
 							   ['AWEDB', 'worker engine mongodb'],
 							   ['M5NR', 'non-redundant sequence database'],
 							   ['solr', 'search engine'],
-							   ['postgresW', 'analysis write database'],
-							   ['postgresR', 'analysis read database'],
+							   ['postgresWRITE', 'analysis write database'],
+							   ['postgresREAD', 'analysis read database'],
 							   ['mySQL', 'job database']
 							 ] ],
 			  "status"  => [ 'boolean', 'service is up or not' ],
@@ -100,7 +100,7 @@ sub instance {
   
   if ($self->{services}->{$id} eq 'db') {
     if ($id =~ /^postgres/) {
-      my $host = ($id eq 'postgresW') ? $Conf::mgrast_write_dbhost : $Conf::mgrast_dbhost
+      my $host = ($id eq 'postgresWRITE') ? $Conf::mgrast_write_dbhost : $Conf::mgrast_dbhost
       my $dbh = DBI->connect(
 			     "DBI:Pg:database=".$Conf::mgrast_db.";host=".$host.";".$Conf::pgsslcert_path,
 			     $Conf::mgrast_dbuser,

--- a/src/MGRAST/lib/resources/heartbeat.pm
+++ b/src/MGRAST/lib/resources/heartbeat.pm
@@ -26,6 +26,7 @@ sub new {
       'AWEDB' => 'mongo',
       'M5NR' => $Conf::m5nr_solr,
       'solr' => $Conf::job_solr,
+      'postgres' => 'db',
       'postgresWRITE' => 'db',
       'postgresREAD' => 'db',
       'mySQL' => 'db',
@@ -40,6 +41,7 @@ sub new {
 							   ['AWEDB', 'worker engine mongodb'],
 							   ['M5NR', 'non-redundant sequence database'],
 							   ['solr', 'search engine'],
+							   ['postgres', 'analysis default database'],
 							   ['postgresWRITE', 'analysis write database'],
 							   ['postgresREAD', 'analysis read database'],
 							   ['mySQL', 'job database']
@@ -100,7 +102,7 @@ sub instance {
   
   if ($self->{services}->{$id} eq 'db') {
     if ($id =~ /^postgres/) {
-      my $host = ($id eq 'postgresWRITE') ? $Conf::mgrast_write_dbhost : $Conf::mgrast_dbhost
+      my $host = ($id eq 'postgresWRITE') ? $Conf::mgrast_write_dbhost : $Conf::mgrast_dbhost;
       my $dbh = DBI->connect(
 			     "DBI:Pg:database=".$Conf::mgrast_db.";host=".$host.";".$Conf::pgsslcert_path,
 			     $Conf::mgrast_dbuser,

--- a/src/MGRAST/lib/resources/heartbeat.pm
+++ b/src/MGRAST/lib/resources/heartbeat.pm
@@ -26,7 +26,8 @@ sub new {
       'AWEDB' => 'mongo',
       'M5NR' => $Conf::m5nr_solr,
       'solr' => $Conf::job_solr,
-      'postgres' => 'db',
+      'postgresW' => 'db',
+      'postgresR' => 'db',
       'mySQL' => 'db',
       'cassandra' => $Conf::cassandra_m5nr
   };
@@ -39,7 +40,8 @@ sub new {
 							   ['AWEDB', 'worker engine mongodb'],
 							   ['M5NR', 'non-redundant sequence database'],
 							   ['solr', 'search engine'],
-							   ['postgres', 'analysis database'],
+							   ['postgresW', 'analysis write database'],
+							   ['postgresR', 'analysis read database'],
 							   ['mySQL', 'job database']
 							 ] ],
 			  "status"  => [ 'boolean', 'service is up or not' ],
@@ -97,9 +99,10 @@ sub instance {
   my $status = 0;
   
   if ($self->{services}->{$id} eq 'db') {
-    if ($id eq 'postgres') {
+    if ($id =~ /^postgres/) {
+      my $host = ($id eq 'postgresW') ? $Conf::mgrast_write_dbhost : $Conf::mgrast_dbhost
       my $dbh = DBI->connect(
-			     "DBI:Pg:database=".$Conf::mgrast_db.";host=".$Conf::mgrast_dbhost.";".$Conf::pgsslcert_path,
+			     "DBI:Pg:database=".$Conf::mgrast_db.";host=".$host.";".$Conf::pgsslcert_path,
 			     $Conf::mgrast_dbuser,
 			     $Conf::mgrast_dbpass
 			    );

--- a/src/MGRAST/lib/resources/job.pm
+++ b/src/MGRAST/lib/resources/job.pm
@@ -405,6 +405,14 @@ sub job_data {
         if ($nodes && (@$nodes > 0)) {
             $self->return_data({"status" => "submitted", "id" => $nodes->[0]->{id}, "url" => $self->cgi->url."/status/".$nodes->[0]->{id}});
         }
+        
+        # test postgres access
+        my $testdb = MGRAST::Abundance->new(undef, $ver, $Conf::mgrast_write_dbhost);
+        unless ($testdb) {
+            $self->return_data({"ERROR" => "unable to connect to metagenomics analysis database"}, 500);
+        }
+        $testdb->DESTROY();
+        
         # need to create new node and fork
         my $node = $self->set_shock_node("asynchronous", undef, $attr, $self->mgrast_token, undef, undef, "7D");
         my $pid = fork();
@@ -840,6 +848,12 @@ sub job_action {
             if ($nodes && (@$nodes > 0)) {
                 $self->return_data({"status" => "submitted", "id" => $nodes->[0]->{id}, "url" => $self->cgi->url."/status/".$nodes->[0]->{id}});
             }
+            # test postgres access
+            my $testdb = MGRAST::Abundance->new(undef, $ver, $Conf::mgrast_write_dbhost);
+            unless ($testdb) {
+                $self->return_data({"ERROR" => "unable to connect to metagenomics analysis database"}, 500);
+            }
+            $testdb->DESTROY();
             # need to create new node and fork
             my $node = $self->set_shock_node("asynchronous", undef, $attr, $self->mgrast_token, undef, undef, "7D");
             my $pid = fork();

--- a/src/MGRAST/lib/resources/m5nr.pm
+++ b/src/MGRAST/lib/resources/m5nr.pm
@@ -6,7 +6,6 @@ no warnings('once');
 
 use List::Util qw(first);
 use List::MoreUtils qw(any uniq);
-use File::Temp qw(tempfile tempdir);
 use URI::Escape;
 use Digest::MD5;
 

--- a/src/MGRAST/lib/resources/matrix.pm
+++ b/src/MGRAST/lib/resources/matrix.pm
@@ -216,6 +216,13 @@ sub instance {
     # unique list and sort it - sort required for proper caching
     my @mgids = sort keys %mgids;
     
+    # test postgres access
+    my $testdb = MGRAST::Abundance->new(undef, $version);
+    unless ($testdb) {
+        $self->return_data({"ERROR" => "unable to connect to metagenomics analysis database"}, 500);
+    }
+    $testdb->DESTROY();
+    
     # asynchronous call, fork the process and return the process id.
     # caching is done with shock, not memcache
     if ($self->cgi->param('asynchronous')) {
@@ -320,7 +327,7 @@ sub prepare_data {
     my $chdl   = $self->cassandra_m5nr_handle("m5nr_v".$version, $Conf::cassandra_m5nr);
     my $mgdb   = MGRAST::Abundance->new($chdl, $version);
     unless (ref($mgdb)) {
-        return ({"ERROR" => "could not connect to analysis database"}, 500);
+        return ({"ERROR" => "unable to connect to metagenomics analysis database"}, 500);
     }
 
     # validate cutoffs

--- a/src/MGRAST/lib/resources/matrix.pm
+++ b/src/MGRAST/lib/resources/matrix.pm
@@ -217,7 +217,7 @@ sub instance {
     my @mgids = sort keys %mgids;
     
     # test postgres access
-    my $testdb = MGRAST::Abundance->new(undef, $version);
+    my $testdb = MGRAST::Abundance->new();
     unless ($testdb) {
         $self->return_data({"ERROR" => "unable to connect to metagenomics analysis database"}, 500);
     }

--- a/src/MGRAST/lib/resources/profile.pm
+++ b/src/MGRAST/lib/resources/profile.pm
@@ -231,7 +231,7 @@ sub submit {
     }
     
     # test postgres access
-    my $testdb = MGRAST::Abundance->new(undef, $version);
+    my $testdb = MGRAST::Abundance->new();
     unless ($testdb) {
         $self->return_data({"ERROR" => "unable to connect to metagenomics analysis database"}, 500);
     }

--- a/src/MGRAST/lib/resources/profile.pm
+++ b/src/MGRAST/lib/resources/profile.pm
@@ -203,7 +203,7 @@ sub submit {
     }
     foreach my $s (@sources) {
         unless (exists $all_srcs->{$s}) {
-            return ({"ERROR" => "Invalid source for profile: ".$s." - valid types are [".join(", ", keys %$all_srcs)."]"}, 400);
+            return ({"ERROR" => "invalid source for profile: ".$s." - valid types are [".join(", ", keys %$all_srcs)."]"}, 400);
         }
     }
     
@@ -229,6 +229,13 @@ sub submit {
         my $obj = $self->status_report_from_node($tnodes->[0], "submitted");
         $self->return_data($obj);
     }
+    
+    # test postgres access
+    my $testdb = MGRAST::Abundance->new(undef, $version);
+    unless ($testdb) {
+        $self->return_data({"ERROR" => "unable to connect to metagenomics analysis database"}, 500);
+    }
+    $testdb->DESTROY();
     
     # need to create new temp node
     $tquery->{row_total} = 0;
@@ -316,6 +323,9 @@ sub prepare_data {
     # db handles
     my $chdl = $self->cassandra_m5nr_handle("m5nr_v".$version, $Conf::cassandra_m5nr);
     my $mgdb = MGRAST::Abundance->new($chdl, $version);
+    unless ($mgdb) {
+        $self->return_data({"ERROR" => "unable to connect to metagenomics analysis database"}, 500);
+    }
     
     # run query
     my $query = "SELECT md5, abundance, exp_avg, len_avg, ident_avg FROM job_md5s WHERE version=".

--- a/src/MGRAST/lib/resources/project.pm
+++ b/src/MGRAST/lib/resources/project.pm
@@ -763,7 +763,7 @@ sub updateRight {
 	$ubody->param('LINK', $WebConfig::APPLICATION_URL."?page=ClaimToken&token=$token&type=project");
 	$ubody->param('APPLICATION_NAME', $WebConfig::APPLICATION_NAME);
 	
-	my $mailer = Mail::Mailer->new();
+	my $mailer = Mail::Mailer->new('smtp', Server => $Conf::smtp_host);
 	if ($mailer->open({ From    => $WebConfig::ADMIN_EMAIL,
 			    To      => $user,
 			    Subject => $WebConfig::APPLICATION_NAME.' - new data available',

--- a/src/MGRAST/lib/resources/resource.pm
+++ b/src/MGRAST/lib/resources/resource.pm
@@ -13,6 +13,7 @@ use MIME::Base64;
 use LWP::UserAgent;
 use HTTP::Request::Common;
 use File::Basename;
+use File::Temp qw(tempfile tempdir);
 use Storable qw(dclone);
 use UUID::Tiny ":std";
 use Digest::MD5 qw(md5_hex md5_base64);

--- a/src/MGRAST/lib/resources/resource.pm
+++ b/src/MGRAST/lib/resources/resource.pm
@@ -727,10 +727,14 @@ sub md5s2sequences {
     }
     
     # get seqs
+    my $ferror = "";
     eval {
         my $fastacmd = $Conf::fastacmd;
         foreach my $line (`$fastacmd -d $m5nr -i $tfile -l 0 -t T -p T`) {
             if ((! $line) || ($line =~ /^\s+$/) || ($line =~ /^\[fastacmd\]/)) {
+                if ($line =~ /ERROR/) {
+                    $ferror .= $line;
+                }
                 next;
             }
             if ($line =~ /^>/) {
@@ -741,6 +745,9 @@ sub md5s2sequences {
     };
     if ($@) {
         return (undef, "unable to access M5NR sequence data");
+    }
+    if ($ferror) {
+        return (undef, $ferror);
     }
     
     # output

--- a/src/WebApplication/WebServerBackend/User.pm
+++ b/src/WebApplication/WebServerBackend/User.pm
@@ -257,7 +257,7 @@ The text of the mail will be I<mail_body>.
 sub send_email {
   my ($self, $from, $subject, $body) = @_;
 
-  my $mailer = Mail::Mailer->new();
+  my $mailer = Mail::Mailer->new('smtp', Server => $Conf::smtp_host);
   $mailer->open({ From    => $from,
 		  To      => $self->email,
 		  Subject => $subject,


### PR DESCRIPTION
- POST md5 list for annotated sequence or similarity
- fasta format for annotated sequences
- 'all' annotations option for annotated sequences
- heartbeat now supports 'postgresWRITE' or 'postgresREAD' servers
- compute resource: blast sequence alignment for given M5NR md5
- optimize md5 seek/length lookup for shock index
- switch from sendmail to smtp for perl mail