### PR TITLE
job library sample reference fix

### DIFF
--- a/src/MGRAST/lib/JobDB/MetaDataCollection.pm
+++ b/src/MGRAST/lib/JobDB/MetaDataCollection.pm
@@ -172,6 +172,15 @@ sub delete_all {
   $self->delete_children;
   $self->delete_entries;
   $self->delete_project;
+  $self->delete_jobentry;
+}
+
+sub delete_jobentry {
+  my ($self) = @_;
+  foreach my $job ( @{ $self->_master->Job->get_objects({sample => $self}) } ) {
+    $job->sample(undef);
+    $job->library(undef);
+  }
 }
 
 sub delete_project {

--- a/src/MGRAST/lib/resources/project.pm
+++ b/src/MGRAST/lib/resources/project.pm
@@ -145,7 +145,7 @@ sub post_action {
     
     # create a new empty project
     if ($rest->[0] eq 'create') {
-        unless ($self->{user} && $self->{user}->has_star_right('edit', 'user')) {
+        unless ($self->{user}) {
             $self->return_data( {"ERROR" => "insufficient permissions for this user call"}, 401 );
         }
         unless ($self->{cgi}->param("user")) {


### PR DESCRIPTION
The reference to sample and library in a job was not deleted when the sample and library were deleted. This is now fixed.

Empty projects can now be created by normal users vs. only superusers.