### PR TITLE
Map decode_utf8 to not mangle multiple-value POST params

### DIFF
--- a/src/MGRAST/lib/resources/resource.pm
+++ b/src/MGRAST/lib/resources/resource.pm
@@ -554,7 +554,7 @@ sub get_post_data {
                 if (scalar(@val) == 1) {
                     $data{$f} = decode_utf8($val[0]);
                 } elsif (scalar(@val) > 1) {
-                    $data{$f} = decode_utf8(\@val);
+                    ($data{$f}) = map {decode_utf8($_)} @val;
                 }
             }
         }


### PR DESCRIPTION
This addresses the issue that metadata/update  fails when given multiple POST metagenome= parameters.

The POST data was being mangled because decode_utf8 does not do the right thing when the input is an array.