### PR TITLE
Two fixes

### DIFF
--- a/src/MGRAST/lib/Metadata.pm
+++ b/src/MGRAST/lib/Metadata.pm
@@ -1027,6 +1027,21 @@ sub clean_value {
   return $val;
 }
 
+# resolve an obfuscated mg-rast id
+# if it is an mg-rast id already, return it as is
+sub idresolve {
+  my ($self, $id) = @_;
+
+  unless ($id =~ /^mgm/ or $id =~ /^mgp/ or $id =~ /^\d+\.\d+$/) {
+    if(length($id) >=10){
+    $id = substr $id, 10;
+    $id = pack (qq{H*},qq{$id});
+   }
+  }
+
+  return $id;
+}
+
 =pod
 
 =item * B<get_unique_for_tag> (Scalar<tag>)
@@ -1498,6 +1513,7 @@ sub add_valid_metadata {
       my $lib_job;
       if ($lib->{data}{metagenome_id} && $lib->{data}{metagenome_id}{value}) {
 	my $lib_mg = $lib->{data}{metagenome_id}{value};
+	$lib_mg = idresolve($lib_mg) ; 
 	$lib_job = ($lib_mg && exists($job_map_id->{$lib_mg})) ? $job_map_id->{$lib_mg} : undef;
       }
 

--- a/src/MGRAST/lib/resources/download.pm
+++ b/src/MGRAST/lib/resources/download.pm
@@ -148,6 +148,7 @@ sub instance {
     my $version = $job->data('pipeline_version')->{pipeline_version} || $self->{default_pipeline_version};
     my ($setlist, $skip) = $self->get_download_set($job->{metagenome_id}, $version, $self->mgrast_token);
     $setlist = $self->fix_download_filenames($setlist, $restid);
+    my $has_human = $self->has_human($setlist, $job);
     $setlist = $self->clean_setlist($setlist, $job);
     
     # return file from shock
@@ -156,6 +157,9 @@ sub instance {
         foreach my $set (@$setlist) {
             if (($set->{file_id} eq $file) || ($set->{file_name} eq $file)) {
                 if (! exists($set->{node_id})) {
+        		if ($has_human) {
+		        $self->return_data( {"ERROR" => "requested file ($file) is suppressed; try file=299.1"}, 403 );
+	}
                     $self->return_data( {"ERROR" => "requested file ($file) is not available"}, 404 );
                 }
                 if ($link) {
@@ -166,6 +170,9 @@ sub instance {
                 }
             }
         }
+        if ($has_human) {
+        $self->return_data( {"ERROR" => "Requested file ($file) has been suppressed; try file=299.1"}, 403 );
+	}
         $self->return_data( {"ERROR" => "requested file ($file) is not available"}, 404 );
     }
     # return stage(s) list


### PR DESCRIPTION
* /download provides a more helpful message for early-stage downloads that are suppressed by policy
* /metagenome/update tolerates a broader range of metagenome_id's.