### PR TITLE
map of POST params was discarding all but first element

### DIFF
--- a/src/MGRAST/lib/resources/resource.pm
+++ b/src/MGRAST/lib/resources/resource.pm
@@ -554,7 +554,7 @@ sub get_post_data {
                 if (scalar(@val) == 1) {
                     $data{$f} = decode_utf8($val[0]);
                 } elsif (scalar(@val) > 1) {
-                    ($data{$f}) = map {decode_utf8($_)} @val;
+                    @{$data{$f}} = map {decode_utf8($_)} @val;
                 }
             }
         }


### PR DESCRIPTION
This mistake was causing metadata/update calls from metazen with multiple metagenomes to fail