### PR TITLE
Clean cassandra query results

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN apt-get install -y python-dev python-pip && \
   pip install \
   openpyxl \
   gspread \
-  xlrd \
+  xlrd==1.2.0 \
   lepl \
   requests_toolbelt \
   cassandra-driver \

--- a/src/MGRAST/pylib/mgrast_cassandra.py
+++ b/src/MGRAST/pylib/mgrast_cassandra.py
@@ -246,7 +246,7 @@ class JobHandle(object):
         rmqLogger(self.channel, 'select', query)
         rows = self.session.execute(query)
         for r in rows:
-            if r[1] == 0:
+            if r[1] == 0 or r[0] is None:  # skip row if zero length, or row is corrupt
                 continue
             pos = bisect.bisect(found, (r[0], None))
             if (pos > 0) and ((found[pos-1][0] + found[pos-1][1]) == r[0]):


### PR DESCRIPTION
After some datasets returned an error when retrieving rows of [None, None] from casandra, added this to prevent failures with this kind of corrupt data.
